### PR TITLE
Fix additional 'Pointer vs Datum' compatibility issues with postgres 16

### DIFF
--- a/Code/PgSQL/rdkit/bfp_gist.c
+++ b/Code/PgSQL/rdkit/bfp_gist.c
@@ -654,9 +654,9 @@ static int
 gbfp_cmp(Datum x, Datum y, SortSupport ssup)
 {
   /* establish order between x and y */
-  GBfp *gbfp1 = (GBfp *)DatumGetPointer(PG_DETOAST_DATUM(x));
+  GBfp *gbfp1 = (GBfp *)PG_DETOAST_DATUM(x);
   Assert(IS_LEAF_KEY(gbfp1));
-  GBfp *gbfp2 = (GBfp *)DatumGetPointer(PG_DETOAST_DATUM(y));
+  GBfp *gbfp2 = (GBfp *)PG_DETOAST_DATUM(y);
   Assert(IS_LEAF_KEY(gbfp2));
 
   int siglen = GBFP_LEAF_SIGLEN(gbfp1);

--- a/Code/PgSQL/rdkit/bfp_gist.c
+++ b/Code/PgSQL/rdkit/bfp_gist.c
@@ -155,7 +155,7 @@ Datum gbfp_decompress(PG_FUNCTION_ARGS) {
   GISTENTRY *retval;
   GBfp *key;
 
-  key = (GBfp *)DatumGetPointer(PG_DETOAST_DATUM(entry->key));
+  key = (GBfp *)PG_DETOAST_DATUM(entry->key);
 
   if (key != (GBfp *)DatumGetPointer(entry->key)) {
     retval = (GISTENTRY *)palloc(sizeof(GISTENTRY));
@@ -617,7 +617,7 @@ PGDLLEXPORT Datum gbfp_fetch(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(gbfp_fetch);
 Datum gbfp_fetch(PG_FUNCTION_ARGS) {
   GISTENTRY *entry = (GISTENTRY *)PG_GETARG_POINTER(0);
-  GBfp *gbfp = (GBfp *)DatumGetPointer(PG_DETOAST_DATUM(entry->key));
+  GBfp *gbfp = (GBfp *)PG_DETOAST_DATUM(entry->key);
 
   GBfpLeafData *data;
 

--- a/Code/PgSQL/rdkit/low_gist.c
+++ b/Code/PgSQL/rdkit/low_gist.c
@@ -65,7 +65,7 @@ PGDLLEXPORT Datum gslfp_decompress(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(gslfp_decompress);
 Datum gslfp_decompress(PG_FUNCTION_ARGS) {
   GISTENTRY *entry = (GISTENTRY *)PG_GETARG_POINTER(0);
-  bytea *key = (bytea *)DatumGetPointer(PG_DETOAST_DATUM(entry->key));
+  bytea *key = (bytea *)PG_DETOAST_DATUM(entry->key);
 
   if (key != (bytea *)DatumGetPointer(entry->key)) {
     GISTENTRY *retval = (GISTENTRY *)palloc(sizeof(GISTENTRY));

--- a/Code/PgSQL/rdkit/rdkit_gist.c
+++ b/Code/PgSQL/rdkit/rdkit_gist.c
@@ -546,8 +546,8 @@ static int
 gmol_cmp(Datum x, Datum y, SortSupport ssup)
 {
   /* establish order between x and y */
-  bytea *a = (bytea*)DatumGetPointer(PG_DETOAST_DATUM(x));
-  bytea *b = (bytea*)DatumGetPointer(PG_DETOAST_DATUM(y));
+  bytea *a = (bytea*)PG_DETOAST_DATUM(x);
+  bytea *b = (bytea*)PG_DETOAST_DATUM(y);
 
   Assert(!ISALLTRUE(a));
   Assert(!ISALLTRUE(b));

--- a/Code/PgSQL/rdkit/rdkit_gist.c
+++ b/Code/PgSQL/rdkit/rdkit_gist.c
@@ -119,7 +119,7 @@ PGDLLEXPORT Datum gmol_decompress(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(gmol_decompress);
 Datum gmol_decompress(PG_FUNCTION_ARGS) {
   GISTENTRY *entry = (GISTENTRY *)PG_GETARG_POINTER(0);
-  bytea *key = (bytea *)DatumGetPointer(PG_DETOAST_DATUM(entry->key));
+  bytea *key = (bytea *)PG_DETOAST_DATUM(entry->key);
 
   if (key != (bytea *)DatumGetPointer(entry->key)) {
     GISTENTRY *retval = (GISTENTRY *)palloc(sizeof(GISTENTRY));


### PR DESCRIPTION
This PR applies the same fix for the Pointer vs Datum issue to locations modified after 2023.03.3